### PR TITLE
ZEIT should be capitalized

### DIFF
--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -12,7 +12,7 @@ export default class Index extends React.Component {
     selectedDeploy: {},
     deployments: [
       {
-        name: 'Zeit Now',
+        name: 'ZEIT Now',
         code: 'process.env.LIGHT_ENVIRONMENT = \'now\';',
       },
       {


### PR DESCRIPTION
This fixes the branding for [ZEIT Now](https://zeit.co/now)