### PR TITLE
Continue watching files with errors

### DIFF
--- a/src/cli/commands/dev.ts
+++ b/src/cli/commands/dev.ts
@@ -74,22 +74,6 @@ const handle = async (argv: Args): Promise<void> => {
     const chokidar = require('chokidar'); // eslint-disable-line
     const watcher = chokidar.watch(cwd);
     watcher.on('ready', (): void => {
-      // TODO: if the following `decache` solution doesn't work, this does
-      // let absolute = '';
-      // Module.prototype.require = new Proxy(Module.prototype.require,{
-      //   apply(target, thisArg, argumentsList){
-      //     let name = argumentsList[0];
-      //     if (path.isAbsolute(name)) {
-      //       absolute = path.dirname(name);
-      //       name = '';
-      //     }
-      //     if (!name.endsWith('.js')) {
-      //       name += '.js';
-      //     }
-      //     delete require.cache[path.join(absolute, name)];
-      //     return Reflect.apply(target, thisArg, argumentsList)
-      //   }
-      // });
       logger.hmr('watching for changes');
     });
     watcher.on('change', (p: string): void => {
@@ -99,7 +83,7 @@ const handle = async (argv: Args): Promise<void> => {
       files.forEach((f): void => {
         decache(f);
       });
-      const routeObjs = importRoutes(files, routesPath);
+      const routeObjs = importRoutes(files, routesPath, true);
       routeObjs.forEach((route: Route): void => {
         addRoute(app.router, route);
       });

--- a/src/utils/import-routes.ts
+++ b/src/utils/import-routes.ts
@@ -1,10 +1,9 @@
-import { IncomingMessage, ServerResponse } from 'http';
-import { relative } from 'path';
 import { METHODS } from 'http';
+import { relative } from 'path';
+
 import Youch from 'youch';
 import forTerminal from 'youch-terminal';
 
-import logger from './logger';
 import RouteType from '../types/route';
 import { light, Route } from '../index';
 
@@ -36,7 +35,7 @@ export default (routes: string[], routesPath: string, safe: boolean = false): Ro
     results.push({
       method: METHODS,
       handler: light(class Index extends Route {
-        public async handler() {
+        public async handler(): Promise<any> {
           const youch = new Youch(err, this.req);
           const json = await youch.toJSON();
           console.log(forTerminal(json)); // eslint-disable-line

--- a/tests/seeds/utils/add-routes/routes/youch.ts
+++ b/tests/seeds/utils/add-routes/routes/youch.ts
@@ -1,0 +1,1 @@
+throw new Error('youch');

--- a/tests/utils/import-routes.ts
+++ b/tests/utils/import-routes.ts
@@ -1,4 +1,8 @@
+import listen from 'test-listen';
+import fetch from 'node-fetch';
 import { join } from 'path';
+
+import { server } from '../../src/index';
 import importRoutes from '../../src/utils/import-routes';
 
 const routesPath = join(__dirname, '../seeds/utils/add-routes/routes');
@@ -23,11 +27,34 @@ describe('utils', () => {
 
     describe('with an invalid route', () => {
       it('throws', async () => {
-        expect.assertions(2);
-        const spy = jest.spyOn(process.stdout, 'write').mockImplementation();
-        expect(() => importRoutes([join(routesPath, './throw.ts')], routesPath)).toThrow('please fix the route and try again');
-        expect(spy).toHaveBeenCalledTimes(2);
+        expect.assertions(1);
+        expect(() => importRoutes([join(routesPath, './throw.ts')], routesPath)).toThrow('error');
+      });
+    });
+
+    // created another file youch as the previous "throw" test causes issues if you use the same file
+    describe('with safe mode', () => {
+      it('returns a single route containing the youch error page', async () => {
+        expect.assertions(5);
+        const routes = importRoutes([join(routesPath, './youch.ts')], routesPath, true);
+        expect(routes.length).toBe(1);
+        expect(Object.keys(routes[0]).sort()).toEqual(['handler', 'method', 'path'].sort());
+
+        const app = server({
+          routes,
+          opts: { disableRequestLogger: true },
+        });
+        const spy = jest.spyOn(console, 'log').mockImplementation();
+
+        const url = await listen(app.server);
+        const req = await fetch(url);
+        const res = await req.text();
+        expect(req.status).toStrictEqual(200);
+        expect(res).toContain('html');
+        expect(spy).toHaveBeenCalledTimes(1);
+
         spy.mockRestore();
+        app.server.close();
       });
     });
   });

--- a/tests/utils/import-routes.ts
+++ b/tests/utils/import-routes.ts
@@ -32,7 +32,7 @@ describe('utils', () => {
       });
     });
 
-    // created another file youch as the previous "throw" test causes issues if you use the same file
+    // using a different file as the previous "throw" test causes issues if you use the same file
     describe('with safe mode', () => {
       it('returns a single route containing the youch error page', async () => {
         expect.assertions(5);


### PR DESCRIPTION
Continues watching files even if they fail to import. It will also bring up a pretty HTML page pointing out the syntax error.

Fixes #35 