### PR TITLE
fix(404): handle 404 errors gracefully

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,9 @@
 import micro from 'micro';
 import Router from 'find-my-way';
 import { IncomingMessage, ServerResponse, Server } from 'http';
+
 import findRoutes from './utils/find-routes';
-import Route from './types/route';
+import RouteType from './types/route';
 import importRoutes from './utils/import-routes';
 import addRoute from './utils/add-route';
 
@@ -14,18 +15,22 @@ interface Light {
 type IM = IncomingMessage;
 type SR = ServerResponse;
 
-const light = ({
+const app = ({
   routes,
   opts,
 }: {
-  routes: string | Route[];
+  routes: string | RouteType[];
   opts?: any;
 }): Light => {
   const router = Router({
     ignoreTrailingSlash: true,
+    defaultRoute: (req: IncomingMessage, res: ServerResponse): void => {
+      res.statusCode = 404;
+      res.end('Not Found');
+    },
   });
 
-  let routeObjs: Route[] = [];
+  let routeObjs: RouteType[] = [];
   if (typeof routes === 'string') {
     const files: string[] = findRoutes(routes);
     routeObjs = importRoutes(files, routes);
@@ -35,7 +40,7 @@ const light = ({
 
   const server = micro(async (req: IM, res: SR): Promise<any> => router.lookup(req, res));
 
-  routeObjs.forEach((route: Route): void => {
+  routeObjs.forEach((route: RouteType): void => {
     addRoute(router, route, opts);
   });
 
@@ -45,4 +50,4 @@ const light = ({
   };
 };
 
-export default light;
+export default app;

--- a/tests/404.ts
+++ b/tests/404.ts
@@ -1,0 +1,44 @@
+import fetch from 'node-fetch';
+import join from 'url-join';
+
+import {
+  test, light, Route,
+} from '../src/index';
+
+let server: any;
+
+beforeEach(async () => {
+  server = await test(light(class Index extends Route {
+    public async handler() {
+      return {
+        hello: 'world',
+      };
+    }
+  }));
+});
+
+afterEach(async () => {
+  server.close();
+});
+
+describe('404', () => {
+  describe('with correct route', () => {
+    it('returns data', async () => {
+      expect.assertions(2);
+      const req = await fetch(server.url);
+      const res = await req.json();
+      expect(req.status).toStrictEqual(200);
+      expect(res).toMatchObject({ hello: 'world' });
+    });
+  });
+
+  describe('with incorrect route', () => {
+    it('returns a 404 error', async () => {
+      expect.assertions(2);
+      const req = await fetch(join(server.url, 'hello'));
+      const res = await req.text();
+      expect(req.status).toStrictEqual(404);
+      expect(res).toBe('Not Found');
+    });
+  });
+});


### PR DESCRIPTION
Add a default route to handle 404 errors.

Fixes #26 