### PR TITLE
fix(runkit): export the correct endpoint for runkit

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -165,7 +165,7 @@ export default (opts?: Options): Route => {
         }
         if (isRunKit) {
           handler = {
-            endpoint: wrapper,
+            endpoint: handler,
           };
         }
       }


### PR DESCRIPTION
Export the function wrapped with `run`.